### PR TITLE
Updates Config Values + Groups For New Endpoint

### DIFF
--- a/src/main/java/com/wintertodt/scouter/WintertodtScouterConfig.java
+++ b/src/main/java/com/wintertodt/scouter/WintertodtScouterConfig.java
@@ -9,8 +9,8 @@ import net.runelite.client.config.ConfigItem;
 
 public interface WintertodtScouterConfig extends Config
 {
-	String NETWORK_UPLINK = "get uplink";
-	String NETWORK_DOWNLINK = "get downlink";
+	String NETWORK_UPLINK = "wtUplink";
+	String NETWORK_DOWNLINK = "wtDownlink";
 
 	@ConfigItem
 			(

--- a/src/main/java/com/wintertodt/scouter/WintertodtScouterOverlayPanel.java
+++ b/src/main/java/com/wintertodt/scouter/WintertodtScouterOverlayPanel.java
@@ -38,7 +38,6 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 public class WintertodtScouterOverlayPanel extends OverlayPanel
 {
     private final WintertodtScouterPlugin plugin;
-    private final String OLD_ENDPOINT = "https://wintertodt-scouter.com/";
 
     @Inject
     private WintertodtScouterOverlayPanel(WintertodtScouterPlugin plugin)
@@ -57,22 +56,12 @@ public class WintertodtScouterOverlayPanel extends OverlayPanel
 
         if (plugin.isPostError())
         {
-            LineComponent l;
-            if(plugin.getWintertodtGetUplink().equals(OLD_ENDPOINT)) {
-                l = LineComponent.builder().left("Wintertodt Scouter Error: You're using the old uplink. Please reset your plugin settings.").build();
-            } else {
-                l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to upload data, check uplink in config.").build();
-            }
+            LineComponent l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to upload data, check uplink in config.").build();
             panelComponent.getChildren().add(l);
         }
         if (plugin.isGetError())
         {
-            LineComponent l;
-            if(plugin.getWintertodtGetDownlink().equals(OLD_ENDPOINT)) {
-                l = LineComponent.builder().left("Wintertodt Scouter Error: You're using the old downlink. Please reset your plugin settings.").build();
-            } else {
-                l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to download data, check downlink in config").build();
-            }
+            LineComponent l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to download data, check downlink in config").build();
             panelComponent.getChildren().add(l);
         }
 

--- a/src/main/java/com/wintertodt/scouter/WintertodtScouterOverlayPanel.java
+++ b/src/main/java/com/wintertodt/scouter/WintertodtScouterOverlayPanel.java
@@ -38,6 +38,7 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 public class WintertodtScouterOverlayPanel extends OverlayPanel
 {
     private final WintertodtScouterPlugin plugin;
+    private final String OLD_ENDPOINT = "https://wintertodt-scouter.com/";
 
     @Inject
     private WintertodtScouterOverlayPanel(WintertodtScouterPlugin plugin)
@@ -56,12 +57,22 @@ public class WintertodtScouterOverlayPanel extends OverlayPanel
 
         if (plugin.isPostError())
         {
-            LineComponent l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to upload data, check uplink in config").build();
+            LineComponent l;
+            if(plugin.getWintertodtGetUplink().equals(OLD_ENDPOINT)) {
+                l = LineComponent.builder().left("Wintertodt Scouter Error: You're using the old uplink. Please reset your plugin settings.").build();
+            } else {
+                l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to upload data, check uplink in config.").build();
+            }
             panelComponent.getChildren().add(l);
         }
         if (plugin.isGetError())
         {
-            LineComponent l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to download data, check downlink in config").build();
+            LineComponent l;
+            if(plugin.getWintertodtGetDownlink().equals(OLD_ENDPOINT)) {
+                l = LineComponent.builder().left("Wintertodt Scouter Error: You're using the old downlink. Please reset your plugin settings.").build();
+            } else {
+                l = LineComponent.builder().left("Wintertodt Scouter Error: Failed to download data, check downlink in config").build();
+            }
             panelComponent.getChildren().add(l);
         }
 

--- a/src/main/java/com/wintertodt/scouter/WintertodtScouterPlugin.java
+++ b/src/main/java/com/wintertodt/scouter/WintertodtScouterPlugin.java
@@ -96,7 +96,7 @@ public class WintertodtScouterPlugin extends Plugin
 	public static final int WINTERTODT_HEALTH_PACKED_ID = 25952282;
 	public static final int WINTERTODT_GAME_TIMER_ID = 25952282;
 
-	static final String CONFIG_GROUP_KEY = "scouter";
+	static final String CONFIG_GROUP_KEY = "wintertodtscouter";
 
 	@Inject
 	private ChatMessageManager chatMessageManager;
@@ -179,10 +179,10 @@ public class WintertodtScouterPlugin extends Plugin
 		switch (event.getKey())
 		{
 			case WintertodtScouterConfig.NETWORK_UPLINK:
-				wintertodtGetUplink = config.wintertodtGetUplinkConfig();
+				wintertodtGetUplink = event.getNewValue();
 				break;
 			case WintertodtScouterConfig.NETWORK_DOWNLINK:
-				wintertodtGetDownlink = config.wintertodtGetDownlinkConfig();
+				wintertodtGetDownlink = event.getNewValue();
 				manager.makeGetRequest();
 				break;
 			default:


### PR DESCRIPTION
Some of the old config values weren't being plumbed in (#1) because the config key names and group were the same, and that led to retrieving saved values for users that had the plugin installed before.

This changes those, and also changes the config group name subscriber to listen to the right config group.