### PR TITLE
Handles null world list with loading indicator

### DIFF
--- a/src/main/java/com/wintertodt/scouter/ui/condensed/WintertodtScouterCondensedPluginPanel.java
+++ b/src/main/java/com/wintertodt/scouter/ui/condensed/WintertodtScouterCondensedPluginPanel.java
@@ -335,7 +335,6 @@ public class WintertodtScouterCondensedPluginPanel extends WintertodtScouterPlug
 			listContainer.setLayout(new GridLayout(0, 1));
 		}
 
-		// Reuse rows if possible
 		int currentWorld = plugin.getCurrentWorld();
 		for (int i = 0; i < sortedBossData.size(); i++)
 		{
@@ -343,10 +342,8 @@ public class WintertodtScouterCondensedPluginPanel extends WintertodtScouterPlug
 			World world = worldResult.findWorld(boss.getWorld());
 			boolean isCurrent = currentWorld == boss.getWorld();
 			if (i < rows.size()) {
-				// Update existing row
 				rows.get(i).updateInfo(boss.getHealth(), boss.getWorld(), boss.getTimer(), isCurrent);
 			} else {
-				// Add new row if needed
 				WintertodtScouterTableRow row = new WintertodtScouterTableRow(world,
 					boss.getWorld(), isCurrent,
 					boss.getHealth(), boss.getTimer(), boss.getTime(), plugin::hopTo);
@@ -354,7 +351,6 @@ public class WintertodtScouterCondensedPluginPanel extends WintertodtScouterPlug
 				rows.add(row);
 			}
 		}
-		// Remove extra rows if any
 		while (rows.size() > sortedBossData.size()) {
 			rows.remove(rows.size() - 1);
 		}


### PR DESCRIPTION
Runelite team wanted me to add a null check outside the loop:

https://github.com/runelite/plugin-hub/pull/8139#issuecomment-2954258113

I added this and then tested by forcing a null check:

![New loading screen if null](https://github.com/user-attachments/assets/51798467-467c-4a05-95a4-766e93e8ef44)


Prevents null pointer errors by checking for a null world list and displaying a loading message when data is unavailable. Improves user experience during world list loading.